### PR TITLE
code for writing to a different log file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,7 @@ linenum.ml
 /locale/
 machine.h
 Makefile
+Makefile.orig
 modelicac
 modelicat
 models

--- a/modules/scicos_blocks/src/c/canimxy.c
+++ b/modules/scicos_blocks/src/c/canimxy.c
@@ -149,9 +149,7 @@ SCICOS_BLOCKS_IMPEXP void canimxy(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     int block_id = 9;
 
     switch (flag)
@@ -215,7 +213,7 @@ SCICOS_BLOCKS_IMPEXP void canimxy(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/canimxy3d.c
+++ b/modules/scicos_blocks/src/c/canimxy3d.c
@@ -151,11 +151,7 @@ SCICOS_BLOCKS_IMPEXP void canimxy3d(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    char fileName[25];
-    // Define file pointer to write data to a log file which can used for output generation to the client
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    // Open file in append mode
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     // Give block id to distinguish blocks
     int block_id = 10;
 
@@ -232,7 +228,7 @@ SCICOS_BLOCKS_IMPEXP void canimxy3d(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/cevscpe.c
+++ b/modules/scicos_blocks/src/c/cevscpe.c
@@ -168,11 +168,7 @@ SCICOS_BLOCKS_IMPEXP void cevscpe(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    // Define file pointer to write data to a log file which can used for output generation to the client
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    // Open file in append mode
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     // Give block id to distinguish blocks
     int block_id = 23;
 
@@ -256,7 +252,7 @@ SCICOS_BLOCKS_IMPEXP void cevscpe(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/cfscope.c
+++ b/modules/scicos_blocks/src/c/cfscope.c
@@ -162,9 +162,7 @@ SCICOS_BLOCKS_IMPEXP void cfscope(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     int block_id = 3;
 
     switch (flag)
@@ -249,7 +247,7 @@ SCICOS_BLOCKS_IMPEXP void cfscope(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/cmscope.c
+++ b/modules/scicos_blocks/src/c/cmscope.c
@@ -217,11 +217,7 @@ SCICOS_BLOCKS_IMPEXP void cmscope(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    // Define file pointer to write data to a log file which can used for output generation to the client
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    // Open file in append mode
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     // Give block id to distinguish blocks
     int block_id = 2;
 
@@ -317,7 +313,7 @@ SCICOS_BLOCKS_IMPEXP void cmscope(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/cscope.c
+++ b/modules/scicos_blocks/src/c/cscope.c
@@ -206,11 +206,7 @@ SCICOS_BLOCKS_IMPEXP void cscope(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    // Define file pointer to write data to a log file which can used for output generation to the client
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    // Open file in append mode
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     // Give block id to distinguish blocks
     int block_id = 1;
 
@@ -297,7 +293,7 @@ SCICOS_BLOCKS_IMPEXP void cscope(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/cscopxy.c
+++ b/modules/scicos_blocks/src/c/cscopxy.c
@@ -148,11 +148,7 @@ SCICOS_BLOCKS_IMPEXP void cscopxy(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    // Define file pointer to write data to a log file which can used for output generation to the client
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    // Open file in append mode
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     // Give block id to distinguish blocks
     int block_id = 4;
 
@@ -224,7 +220,7 @@ SCICOS_BLOCKS_IMPEXP void cscopxy(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/cscopxy3d.c
+++ b/modules/scicos_blocks/src/c/cscopxy3d.c
@@ -151,11 +151,7 @@ SCICOS_BLOCKS_IMPEXP void cscopxy3d(scicos_block * block, scicos_flag flag)
     BOOL result;
 
     int processId = getpid();
-    // Define file pointer to write data to a log file which can used for output generation to the client
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    // Open file in append mode
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     // Give block id to distinguish blocks
     int block_id = 5;
 
@@ -229,7 +225,7 @@ SCICOS_BLOCKS_IMPEXP void cscopxy3d(scicos_block * block, scicos_flag flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 /*-------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/writeau.c
+++ b/modules/scicos_blocks/src/c/writeau.c
@@ -50,9 +50,7 @@ ipar[7:6+lfil] = character codes for file name
 */
 {
     int processId = getpid();
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     int block_id = 22;
     char str[100];
 
@@ -164,7 +162,7 @@ ipar[7:6+lfil] = character codes for file name
         fclose(fd);
         z[2] = 0.0;
     }
-    fclose(filePointer);
+    fflush(filePointer);
     return;
 }
 /*--------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/c/writec.c
+++ b/modules/scicos_blocks/src/c/writec.c
@@ -52,9 +52,7 @@ ipar[7:6+lfil] = character codes for file name
 
 {
     int processId = getpid();
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     int block_id = 21;
 
     char str[100], type[4];
@@ -152,7 +150,7 @@ ipar[7:6+lfil] = character codes for file name
         fprintf(filePointer, "%d || Ending %d\n", processId,  get_block_number());
         z[2] = 0.0;
     }
-    fclose(filePointer);
+    fflush(filePointer);
     return;
 }
 /*--------------------------------------------------------------------------*/

--- a/modules/scicos_blocks/src/cpp/affich2.cpp
+++ b/modules/scicos_blocks/src/cpp/affich2.cpp
@@ -47,9 +47,7 @@ SCICOS_BLOCKS_IMPEXP void affich2(scicos_block * block, int flag)
     char pstConv[128];
 
     int processId = getpid();
-    char fileName[25];
-    sprintf(fileName, "scilab-log-%d.txt", processId);
-    FILE *filePointer = fopen(fileName, "a");
+    FILE *filePointer = getLogFilePointer();
     int block_id = 20;
     double time = 0;
 
@@ -152,7 +150,7 @@ SCICOS_BLOCKS_IMPEXP void affich2(scicos_block * block, int flag)
         default:
             break;
     }
-    fclose(filePointer);
+    fflush(filePointer);
 }
 
 //

--- a/modules/scicos_blocks/src/cpp/scoUtils.cpp
+++ b/modules/scicos_blocks/src/cpp/scoUtils.cpp
@@ -95,6 +95,31 @@ BOOL setLabel(int iAxeUID, int _iName, char* pstLabel)
     return (BOOL) (result && iLabelUID != 0);
 }
 
+# define LOG_FILE_FD 123
+FILE *logFilePointer = NULL;
+
+FILE *getLogFilePointer(void)
+{
+    char filename[25];
+
+    if (logFilePointer == NULL)
+    {
+        logFilePointer = fdopen(LOG_FILE_FD, "a");
+        if (logFilePointer == NULL)
+        {
+            fprintf(stderr, "Could not fdopen %d: %m\n", LOG_FILE_FD);
+            sprintf(filename, "scilab-log-%d.txt", getpid());
+            logFilePointer = fopen(filename, "a");
+            if (logFilePointer == NULL)
+            {
+                fprintf(stderr, "Could not fopen %s: %m\n", filename);
+            }
+        }
+    }
+
+    return logFilePointer;
+}
+
 long getMicrotime(void) {
     struct timeval currentTime;
     gettimeofday(&currentTime, NULL);

--- a/modules/scicos_blocks/src/cpp/scoUtils.h
+++ b/modules/scicos_blocks/src/cpp/scoUtils.h
@@ -38,6 +38,13 @@ int findChildWithKindAt(int parent, int type, const int position);
 BOOL setLabel(int iAxeUID, int _iName, char* pstLabel);
 
 /**
+ * Get the file pointer
+ *
+ * \return the file pointer to the log file
+ */
+FILE *getLogFilePointer(void);
+
+/**
  * get the current time
  *
  * \return the current time in microseconds


### PR DESCRIPTION
File descriptor 123 is first attempted to open for writing the log
lines. If this fails, scilab-log-<pid>.txt is opened for writing those
log lines. This is for compatibility with the existing code.

This change is used in the xcos-on-cloud code.